### PR TITLE
Remove eval

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
 
 # Uniform block layout
 Layout/SpaceBeforeBlockBraces:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,10 +9,6 @@ Layout/SpaceBeforeBlockBraces:
 Metrics/LineLength:
   Max: 92
 
-# Using eval is the bread and butter of Iba
-Security/Eval:
-  Enabled: false
-
 # Prefer no parentheses in method definitions
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,8 +29,3 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
     - 'lib/iba.rb'
-
-# Offense count: 6
-Style/EvalWithLocation:
-  Exclude:
-    - 'lib/iba.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: trusty
 language: ruby
 rvm:
-  - 2.1.9
   - 2.2.6
   - 2.3.3
+  - 2.4.2
   - jruby-9.1.6.0
   - jruby-head
   - rubinius-3.69

--- a/iba.gemspec
+++ b/iba.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
 
   s.summary = 'Introspective Block Assertions'
   s.description = 'Asserts blocks, prints introspective failure messages.'
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.authors = ['Matijs van Zuijlen']
   s.email = ['matijs@matijs.net']

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -74,9 +74,7 @@ module Iba
     def _override_instance_variables vars
       vars.each do |v|
         next if v =~ /^@_/
-        instance_variable_set v, Iba::MethodCallExpression.new(Iba::EmptyExpression.new,
-                                                               v.to_sym,
-                                                               [])
+        instance_variable_set v, Iba::InstanceVariableExpression.new(v.to_sym)
       end
     end
 
@@ -109,6 +107,24 @@ module Iba
 
     def _to_s
       @value.inspect
+    end
+  end
+
+  class InstanceVariableExpression < BaseExpression
+    def initialize ivar_name
+      @_ivar_name = ivar_name
+    end
+
+    def _to_s
+      @_ivar_name.to_s
+    end
+
+    def to_s
+      method_missing :to_s
+    end
+
+    def == other
+      method_missing :==, other
     end
   end
 

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -41,19 +41,18 @@ module Iba
   end
 
   class BaseExpression
-
-  end
-
-  class EmptyExpression < BaseExpression
     def method_missing method, *args
       super if method.to_s =~ /^_/
       MethodCallExpression.new self, method, args
     end
 
-    def respond_to_missing? _method
+    def respond_to_missing? method
+      return false if method.to_s =~ /^_/
       true
     end
+  end
 
+  class EmptyExpression < BaseExpression
     def _parse &blk
       b = blk.binding
 
@@ -143,15 +142,6 @@ module Iba
         str << "(#{args.join(', ')})" unless @_args.empty?
         str
       end
-    end
-
-    def method_missing method, *args
-      super if method.to_s =~ /^_/
-      MethodCallExpression.new self, method, args
-    end
-
-    def respond_to_missing? _method
-      true
     end
 
     def method_is_operator?

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -143,7 +143,7 @@ module Iba
 
       if @_method == :[]
         "#{rcv}[#{args[0]}]"
-      elsif method_is_operator?
+      elsif _method_is_operator?
         case @_args.length
         when 0
           "#{@_method.to_s.sub(/@$/, '')}#{rcv}"
@@ -160,11 +160,11 @@ module Iba
       end
     end
 
-    def method_is_operator?
+    private
+
+    def _method_is_operator?
       @_method.to_s !~ /^[a-z]/
     end
-
-    private
 
     def _wrap arg
       if arg.class == MethodCallExpression

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -66,6 +66,10 @@ module Iba
         LiteralExpression.new arg
       end
     end
+
+    def coerce other
+      [_wrap(other), self]
+    end
   end
 
   class EmptyExpression < BaseExpression

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -35,7 +35,8 @@ module Iba
         nil
       else
         str = expr._to_s
-        "#{str} is #{@block.binding.eval(str).inspect}"
+        value = expr._evaluate(@block.binding).inspect
+        "#{str} is #{value}"
       end
     end
   end
@@ -126,6 +127,10 @@ module Iba
     def _to_s
       @value.inspect
     end
+
+    def _evaluate _bnd
+      @value
+    end
   end
 
   class InstanceVariableExpression < BaseExpression
@@ -136,6 +141,10 @@ module Iba
     def _to_s
       @_ivar_name.to_s
     end
+
+    def _evaluate bnd
+      bnd.receiver.instance_variable_get @_ivar_name
+    end
   end
 
   class LocalVariableExpression < BaseExpression
@@ -145,6 +154,10 @@ module Iba
 
     def _to_s
       @_lvar_name.to_s
+    end
+
+    def _evaluate bnd
+      bnd.local_variable_get @_lvar_name
     end
   end
 
@@ -178,6 +191,12 @@ module Iba
         str << "(#{args.join(', ')})" unless @_args.empty?
         str
       end
+    end
+
+    def _evaluate bnd
+      rcv = @_reciever._evaluate(bnd)
+      args = @_args.map { |arg| arg._evaluate(bnd) }
+      rcv.send @_method, *args
     end
 
     private

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -40,7 +40,11 @@ module Iba
     end
   end
 
-  class EmptyExpression
+  class BaseExpression
+
+  end
+
+  class EmptyExpression < BaseExpression
     def method_missing method, *args
       super if method.to_s =~ /^_/
       MethodCallExpression.new self, method, args
@@ -61,7 +65,7 @@ module Iba
       _override_local_variables vars, b
 
       result = instance_eval(&blk)
-      result = LiteralExpression.new(result) unless result.class == MethodCallExpression
+      result = LiteralExpression.new(result) unless result.is_a? BaseExpression
 
       _restore_local_variables vars, b
 
@@ -99,7 +103,7 @@ module Iba
     end
   end
 
-  class LiteralExpression
+  class LiteralExpression < BaseExpression
     def initialize val
       @value = val
     end
@@ -109,7 +113,7 @@ module Iba
     end
   end
 
-  class MethodCallExpression
+  class MethodCallExpression < BaseExpression
     attr_reader :_method, :_reciever, :_args
 
     def initialize reciever, methodname, args

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -58,6 +58,14 @@ module Iba
     def == other
       method_missing :==, other
     end
+
+    def _wrap arg
+      if arg.is_a? BaseExpression
+        arg
+      else
+        LiteralExpression.new arg
+      end
+    end
   end
 
   class EmptyExpression < BaseExpression
@@ -72,7 +80,7 @@ module Iba
       _override_local_variables vars, b
 
       result = instance_eval(&blk)
-      result = LiteralExpression.new(result) unless result.is_a? BaseExpression
+      result = _wrap(result)
 
       _restore_local_variables vars, b
 
@@ -164,14 +172,6 @@ module Iba
 
     def _method_is_operator?
       @_method.to_s !~ /^[a-z]/
-    end
-
-    def _wrap arg
-      if arg.class == MethodCallExpression
-        arg
-      else
-        LiteralExpression.new arg
-      end
     end
   end
 

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -102,9 +102,7 @@ module Iba
       vars.each do |v|
         next if v =~ /^_/
         b.local_variable_set "_#{v}", b.local_variable_get(v)
-        b.local_variable_set v, Iba::MethodCallExpression.new(Iba::EmptyExpression.new,
-                                                              v.to_sym,
-                                                              [])
+        b.local_variable_set v, LocalVariableExpression.new(v.to_sym)
       end
     end
 
@@ -137,6 +135,16 @@ module Iba
 
     def _to_s
       @_ivar_name.to_s
+    end
+  end
+
+  class LocalVariableExpression < BaseExpression
+    def initialize lvar_name
+      @_lvar_name = lvar_name
+    end
+
+    def _to_s
+      @_lvar_name.to_s
     end
   end
 

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -50,6 +50,14 @@ module Iba
       return false if method.to_s =~ /^_/
       true
     end
+
+    def to_s
+      method_missing :to_s
+    end
+
+    def == other
+      method_missing :==, other
+    end
   end
 
   class EmptyExpression < BaseExpression
@@ -118,14 +126,6 @@ module Iba
     def _to_s
       @_ivar_name.to_s
     end
-
-    def to_s
-      method_missing :to_s
-    end
-
-    def == other
-      method_missing :==, other
-    end
   end
 
   class MethodCallExpression < BaseExpression
@@ -162,14 +162,6 @@ module Iba
 
     def method_is_operator?
       @_method.to_s !~ /^[a-z]/
-    end
-
-    def to_s
-      method_missing :to_s
-    end
-
-    def == other
-      method_missing :==, other
     end
 
     private

--- a/lib/iba.rb
+++ b/lib/iba.rb
@@ -35,7 +35,7 @@ module Iba
         nil
       else
         str = expr._to_s
-        "#{str} is #{eval(str, @block.binding).inspect}"
+        "#{str} is #{@block.binding.eval(str).inspect}"
       end
     end
   end

--- a/test/analyse_test.rb
+++ b/test/analyse_test.rb
@@ -64,4 +64,15 @@ class AnalyseTest < Test::Unit::TestCase
     @foo = 23
     assert_equal '(23 + @foo) is 46', combinator { 23 + @foo }.analyse
   end
+
+  def test_complex_subexpressions
+    @foo = 23
+    bar = 42
+    baz = [42]
+    result = combinator { (@foo + baz.first) == (bar + 23) }.analyse
+    assert_equal \
+      "((@foo + baz.first) == (bar + 23)) is true\n" \
+      '(@foo + baz.first) is 65, (bar + 23) is 65',
+      result
+  end
 end

--- a/test/analyse_test.rb
+++ b/test/analyse_test.rb
@@ -54,4 +54,14 @@ class AnalyseTest < Test::Unit::TestCase
     @foo = 23
     assert_equal '@foo is 23', combinator { @foo }.analyse
   end
+
+  def test_instance_variable_method_call
+    @foo = 23
+    assert_equal "(@foo == 23) is true\n@foo is 23", combinator { @foo == 23 }.analyse
+  end
+
+  def test_instance_variable_as_argument_of_operator
+    @foo = 23
+    assert_equal '(23 + @foo) is 46', combinator { 23 + @foo }.analyse
+  end
 end


### PR DESCRIPTION
Who'd have thought you can replace `eval` with specific method calls on `Binding` and an expression evaluator?