### PR TITLE
Fix build infrastructure

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,0 +1,4 @@
+lib/iba.rb
+COPYING.LESSER
+LICENSE
+README.rdoc

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "rake/clean"
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "rake/manifest/task"
 
 namespace :test do
   Rake::TestTask.new(:run) do |t|
@@ -12,7 +13,13 @@ namespace :test do
   end
 end
 
+Rake::Manifest::Task.new do |t|
+  t.patterns = ["lib/**/*", "COPYING.LESSER", "LICENSE", "*.rdoc"]
+end
+
 desc "Alias to test:run"
 task test: "test:run"
+
+task build: "manifest:check"
 
 task default: "test:run"

--- a/iba.gemspec
+++ b/iba.gemspec
@@ -1,35 +1,29 @@
 # frozen_string_literal: true
 
-require "rake/file_list"
+Gem::Specification.new do |spec|
+  spec.name = "iba"
+  spec.version = "0.0.5"
+  spec.authors = ["Matijs van Zuijlen"]
+  spec.email = ["matijs@matijs.net"]
 
-Gem::Specification.new do |s|
-  s.name = "iba"
-  s.version = "0.0.5"
-  s.summary = "Introspective Block Assertions"
-  s.authors = ["Matijs van Zuijlen"]
-  s.email = ["matijs@matijs.net"]
-  s.homepage = "http://www.github.com/mvz/iba"
-
-  s.required_ruby_version = ">= 2.5.0"
-
-  s.license = "LGPL-3.0+"
-
-  s.description = <<~DESC
+  spec.summary = "Introspective Block Assertions"
+  spec.description = <<~DESC
     Asserts blocks, prints introspective failure messages.
   DESC
+  spec.homepage = "http://www.github.com/mvz/iba"
+  spec.license = "LGPL-3.0+"
 
-  s.files =
-    Rake::FileList["{lib,test,tasks}/**/*",
-                   "COPYING.LESSER", "LICENSE", "*.rdoc", "Rakefile"]
-    .exclude(*File.read(".gitignore").split)
+  spec.required_ruby_version = ">= 2.5.0"
 
-  s.rdoc_options = ["--main", "README.rdoc"]
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/mvz/iba"
 
-  s.extra_rdoc_files = ["README.rdoc", "LICENSE", "COPYING.LESSER"]
-  s.test_files = `git ls-files -z -- test`.split("\0")
+  spec.files = File.read("Manifest.txt").split
+  spec.rdoc_options = ["--main", "README.rdoc"]
+  spec.extra_rdoc_files = ["README.rdoc", "LICENSE", "COPYING.LESSER"]
+  spec.require_paths = ["lib"]
 
-  s.add_development_dependency("rake", ["~> 13.0"])
-  s.add_development_dependency("test-unit", ["~> 3.1"])
-
-  s.require_paths = ["lib"]
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-manifest", "~> 0.1.0"
+  spec.add_development_dependency "test-unit", "~> 3.1"
 end


### PR DESCRIPTION
Replaces the use of Rake::FileList with a manifest file maintained using rake-manifest. Rake::FileList is not always available in a Ruby installation at the point where the gemspec is read. This is mainly an issue on CI.