### PR TITLE
Allow starting the GitHub Actions workflow manually

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,6 +11,7 @@ name: CI
     branches: [master]
   schedule:
     - cron: '16 4 12 * *'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This is useful if the workflow has been disabled due to inactivity.
