### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "jruby-9.4"]
+        ruby: ["3.1", "3.2", "3.3", "jruby-9.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/iba.gemspec
+++ b/iba.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |spec|
     Asserts blocks, prints introspective failure messages.
   DESC
   spec.homepage = "http://www.github.com/mvz/iba"
+
   spec.license = "LGPL-3.0+"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/iba"

--- a/test/assert_test.rb
+++ b/test/assert_test.rb
@@ -8,8 +8,8 @@ class AssertTest < Test::Unit::TestCase
     assert { true }
   end
 
-  def failing_block_assertion_test(message, &block)
-    assert(&block)
+  def failing_block_assertion_test(message, &)
+    assert(&)
   rescue Exception => e
     assert_equal message, e.message
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ require "iba"
 class Test::Unit::TestCase
   include Iba::BlockAssertion
 
-  def combinator(&blk)
-    Iba::Combinator.new(&blk)
+  def combinator(&)
+    Iba::Combinator.new(&)
   end
 end


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
